### PR TITLE
Ship an explicit module descriptor in microprofile-fault-tolerance-api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,11 +39,66 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <!--
+                Pulled transitively by CDI 3.0 as 2.0.0, which carries no module name. 2.1.0 is the
+                first release with a module descriptor (still Java 8 bytecode) and is needed to
+                resolve `requires jakarta.interceptor` in module-info.java.
+            -->
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
             <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!--
+                        The module descriptor is compiled in a dedicated execution, patched onto the
+                        already compiled classes. This keeps the main compilation unchanged (class path)
+                        and avoids requiring the OSGi/bnd annotation jars referenced by package-info.java,
+                        which are compile-time only and ship no module descriptor.
+                    -->
+                    <execution>
+                        <id>compile-module-info</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <!-- module-info requires at least Java 9; the other classes stay on the project baseline. -->
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/module-info</compileSourceRoot>
+                            </compileSourceRoots>
+                            <compilerArgs>
+                                <arg>--patch-module</arg>
+                                <arg>org.eclipse.microprofile.faulttolerance=${project.build.outputDirectory}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <legacyMode>true</legacyMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -91,11 +91,37 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Register the descriptor source root only once compilation is over, so that the
+                        sources jar ships module-info.java while the default compilation keeps ignoring it.
+                    -->
+                    <execution>
+                        <id>add-module-info-source</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/module-info</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <!--
+                        Keep javadoc in class path mode: a module-info.java at the root of a source path would switch
+                        it to module mode, so only the regular sources are documented.
+                    -->
                     <legacyMode>true</legacyMode>
+                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
                 </configuration>
             </plugin>
         </plugins>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,7 +72,7 @@
                     -->
                     <execution>
                         <id>compile-module-info</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -19,12 +19,6 @@
 
 /**
  * MicroProfile Fault Tolerance API.
- *
- * <p>
- * The fault tolerance annotations ({@code @Retry}, {@code @Timeout}, {@code @Fallback}, ...) are
- * meta-annotated with {@code jakarta.interceptor.InterceptorBinding}, and most of their members are
- * {@code jakarta.enterprise.util.Nonbinding}. Those modules are required transitively so that a CDI
- * container can resolve the bindings from any module reading this API on the module path.
  */
 module org.eclipse.microprofile.faulttolerance {
     requires transitive jakarta.cdi;

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -21,8 +21,8 @@
  * MicroProfile Fault Tolerance API.
  */
 module org.eclipse.microprofile.faulttolerance {
-    requires transitive jakarta.cdi;
-    requires transitive jakarta.interceptor;
+    requires static transitive jakarta.cdi;
+    requires static transitive jakarta.interceptor;
 
     exports org.eclipse.microprofile.faulttolerance;
     exports org.eclipse.microprofile.faulttolerance.exceptions;

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MicroProfile Fault Tolerance API.
+ *
+ * <p>
+ * The fault tolerance annotations ({@code @Retry}, {@code @Timeout}, {@code @Fallback}, ...) are
+ * meta-annotated with {@code jakarta.interceptor.InterceptorBinding} and
+ * {@code jakarta.enterprise.util.Nonbinding}. Those modules are required transitively so that a CDI
+ * container can resolve the bindings from any module reading this API on the module path.
+ */
+module org.eclipse.microprofile.faulttolerance {
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.interceptor;
+
+    exports org.eclipse.microprofile.faulttolerance;
+    exports org.eclipse.microprofile.faulttolerance.exceptions;
+}

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -22,7 +22,7 @@
  *
  * <p>
  * The fault tolerance annotations ({@code @Retry}, {@code @Timeout}, {@code @Fallback}, ...) are
- * meta-annotated with {@code jakarta.interceptor.InterceptorBinding} and
+ * meta-annotated with {@code jakarta.interceptor.InterceptorBinding}, and most of their members are
  * {@code jakarta.enterprise.util.Nonbinding}. Those modules are required transitively so that a CDI
  * container can resolve the bindings from any module reading this API on the module path.
  */


### PR DESCRIPTION
Fixes #659

Adds an explicit `module-info.java` to `microprofile-fault-tolerance-api` so the MicroProfile Fault Tolerance API can be consumed as a proper Java module instead of an automatic one (context: [mailing-list thread](https://groups.google.com/g/microprofile/c/h2e3FicNw5k), same change proposed for every affected MicroProfile API).

The change is designed to be **mergeable in a 4.x release without touching the Java 8 baseline**: the API classes are still compiled with `--release 8`, and the only Java 9 element is the `module-info.class` itself, compiled by a dedicated execution (the approach used by e.g. SLF4J 2.x). Moving to `microprofile-parent` 3.x / Java 11 is a separate decision for the project; if and when it happens, the special-casing below disappears and the wiring becomes identical to the Health and Metrics PRs.

### The descriptor

```java
module org.eclipse.microprofile.faulttolerance {
    requires static transitive jakarta.cdi;
    requires static transitive jakarta.interceptor;

    exports org.eclipse.microprofile.faulttolerance;
    exports org.eclipse.microprofile.faulttolerance.exceptions;
}
```

The module name follows the `org.eclipse.microprofile.<spec>` convention (reverse-DNS of the root package, as already used by the Config API's `Automatic-Module-Name` and by the OpenAPI API's existing descriptor). The Jakarta modules are only referenced by the fault tolerance annotations (`@InterceptorBinding` on every annotation type, `@Nonbinding` on most of their members); the exception types and the rest of the API are pure Java. They are therefore declared `requires static transitive`:

- `static`: optional at resolution time, so the module resolves on a module path without a CDI container — as proposed in #659. Whenever the annotations are actually used at run time it is through a CDI container, whose own module `requires` the Jakarta modules and therefore resolves them.
- `transitive`: when they are resolved, a module using `@Retry` & co. reads `jakarta.cdi` and `jakarta.interceptor` implicitly, which is needed for the meta-annotations to be resolvable from that module.

The same trade-off is applied to the other MicroProfile APIs whose Jakarta dependency is annotation-only (see the discussion on microprofile/microprofile-health#344 and microprofile/microprofile-metrics#805). The module Javadoc is deliberately kept to a one-liner; this rationale lives here instead.

### Build changes (`api/pom.xml`)

- The descriptor lives in `src/main/module-info/` and is compiled by a dedicated `maven-compiler-plugin` execution patched onto the already compiled classes (`--patch-module`). The main compilation is left untouched on the class path, and the descriptor does not have to `requires` the OSGi/bnd annotation jars used by `package-info.java`, which are compile-time only and ship no module descriptor of their own.
- The descriptor source root is registered with `build-helper-maven-plugin` at `prepare-package` (after compilation) so that the attached `*-sources.jar` ships `module-info.java` alongside the other sources.
- `maven-javadoc-plugin` is kept in class path mode (`legacyMode`) with an explicit `sourcepath` limited to `src/main/java`: javadoc would otherwise switch to module mode as soon as it finds a `module-info.java` at the root of a source path.
- The project baseline is Java 8 (`microprofile-parent` 2.x), so the dedicated execution uses `--release 9` — the only Java 9 exception in the build, so that this can land in a 4.x release without waiting for a Java baseline bump. Should the project move to `microprofile-parent` 3.x (Java 11), this special case simply goes away and the wiring becomes identical to the Health/Metrics PRs. The resulting `module-info.class` (class file version 53) sits at the jar root next to Java 8 classes — the same layout used by e.g. SLF4J 2.x; a Java 8 runtime never loads `module-info` and OSGi/bnd ignore it. Packaging it as `META-INF/versions/9/` (multi-release) is possible too if the project prefers.
- `jakarta.interceptor-api` 2.1.0 is declared explicitly in `provided` scope. The 2.0.0 pulled transitively by CDI 3.0 has no module name at all (neither descriptor nor `Automatic-Module-Name`), so `requires jakarta.interceptor` could not be resolved. 2.1.0 is still Java 8 bytecode and is the first release with a module descriptor.

### Verification

- `mvn install -DskipTests` on the whole reactor passes.
- `jar --describe-module` on the built jar shows the descriptor above; OSGi headers (`Bundle-SymbolicName`, `Export-Package`, `Import-Package`) generated by bnd are unchanged.
- `java --module-path <api jar + compile deps> --describe-module org.eclipse.microprofile.faulttolerance` resolves the module graph successfully; with the api jar alone on the module path it resolves as well (optional Jakarta modules).
- The `*-sources.jar` contains `module-info.java`; the `*-javadoc.jar` is unchanged.

